### PR TITLE
Set MAX_BPI to 128, to allow 32 bars long loops

### DIFF
--- a/ninjam/server/usercon.h
+++ b/ninjam/server/usercon.h
@@ -54,7 +54,7 @@
 #define PRIV_VOTE 128
 
 #define MAX_BPM 400
-#define MAX_BPI 64
+#define MAX_BPI 128
 #define MIN_BPM 40
 #define MIN_BPI 2
 


### PR DESCRIPTION
Many jazz standards are 32 bars long. While it's possible to change this settings from the Ninjam console, it would be nice to be able to get this value from the config file (and block the console changes).